### PR TITLE
ASTERISK_FILE_VERSION is deprecated

### DIFF
--- a/app_flite.c
+++ b/app_flite.c
@@ -33,7 +33,7 @@
 
 #include "asterisk.h"
 
-ASTERISK_FILE_VERSION(__FILE__, "$Revision: 00 $")
+ASTERISK_REGISTER_FILE()
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
ASTERISK_FILE_VERSION is deprecated and has been replaced with ASTERISK_REGISTER_FILE.

This causes compilation to fail with Asterisk 14 and higher.
